### PR TITLE
Fix wget command not found error

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -6,6 +6,6 @@ Architecture: all
 Homepage: https://github.com/devleonardoamaral/debian-nvidia-installer
 Maintainer: Leonardo Amaral <leonardo_amaral98@hotmail.com>
 Depends: mokutil, dialog, pciutils, findutils
-Description: NVIDIA driver installer with a Bash TUI. 
+Description: NVIDIA driver installer with a Bash TUI.
  This tool allows you to install NVIDIA drivers on Debian using an interactive text-based interface (TUI).
  It automates steps such as package installation, compatibility checks, and graphics environment configuration.

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -5,7 +5,7 @@ Priority: optional
 Architecture: all
 Homepage: https://github.com/devleonardoamaral/debian-nvidia-installer
 Maintainer: Leonardo Amaral <leonardo_amaral98@hotmail.com>
-Depends: mokutil, dialog, pciutils, findutils
+Depends: mokutil, dialog, pciutils, findutils, wget
 Description: NVIDIA driver installer with a Bash TUI.
  This tool allows you to install NVIDIA drivers on Debian using an interactive text-based interface (TUI).
  It automates steps such as package installation, compatibility checks, and graphics environment configuration.


### PR DESCRIPTION
Added `wget` to the dependencies list to resolve the following error on fresh default installations of Debian 13.
```
/usr/lib/debian-nvidia-installer/cudarepo.sh: line 95: wget: command not found
CRITICAL: Failed to download the CUDA repository installation package. Operation aborted.
```

The error occurs on fresh default installations of Debian 13 while installing any of the 575 or 580 driver flavors because the `usr/lib/debian-nvidia-installer/cudarepo.sh` script uses `wget` to fetch the keyring but `wget` is not installed by default.