### PR TITLE
docs: update README to reflect new DEB build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,83 +34,70 @@ sudo debian-nvidia-installer
 
 You can install `debian-nvidia-installer` by downloading the `.deb` package from the **[Releases](https://github.com/devleonardoamaral/debian-nvidia-installer/releases)** section of this repository.
 
-### Option 1: Graphical Interface (GUI)
+### Option 1: Graphical Interface
 
-1. Download the script’s `.deb` file.
-2. **Double-click** the file to open it in your system’s package manager.
-3. Click **“Install”**. You may be asked to enter your administrator password.
+1. Download the `.deb` package.
+2. **Double-click** the file to open it with your system's package manager.
+3. Click **“Install”**. You may be prompted to enter your administrator password.
 
-> 💡 Compatible with package managers like **GDebi**, **Discover** (KDE), **GNOME Software**, and similar tools.
+> 💡 Compatible with package managers such as GDebi, Discover (KDE), GNOME Software, and similar tools.
 
 ### Option 2: Terminal
 
-Before you start, **check the version of the script you downloaded from GitHub**.
-Replace `X.X.X` in the commands below with the correct version.
-For example, if the version is `0.0.1`, the file will be `debian-nvidia-installer_0.0.1.deb`.
+Before starting, check the version of the `.deb` package you downloaded from GitHub. Replace `X.X.X` in the commands below with the correct version.
+For example, if the version is `0.0.1`, the file will be `debian-nvidia-installer_0.0.1_amd64.deb`.
 
-> ⚠️ **Important:** do not install the file directly from the download location. Always move it to the temporary directory (`/tmp`) to avoid permission issues.
-
-#### Step 1 – Move the file to the temporary directory
+Copy the `.deb` file to the `/tmp` directory to avoid permission issues with the system package manager:
 
 ```bash
-mv ./debian-nvidia-installer_X.X.X.deb /tmp/
+cp ./debian-nvidia-installer_X.X.X_amd64.deb /tmp/
 ```
 
-This moves the `.deb` file to `/tmp`, which is safe for installing packages without special permissions.
+> 💡 Files in the `/tmp` directory are automatically removed after a system reboot.
 
-#### Step 2 – Enter the temporary directory
+Change to the temporary directory `/tmp`, where the `.deb` file was moved:
 
 ```bash
 cd /tmp
 ```
 
-The `cd` command means “change directory.” Here you enter the `/tmp` folder where the file was moved.
-
-#### Step 3 – Install the package
+Install the package using `apt` so that the script dependencies are installed correctly:
 
 ```bash
-sudo apt install ./debian-nvidia-installer_X.X.X.deb
+sudo apt install ./debian-nvidia-installer_X.X.X_amd64.deb
 ```
 
-#### Step 4 – Clean up the file after installation (optional)
+> ⚠️ **Important:** Do not install using `dpkg -i`, as this will not resolve the package dependencies and the package may break.
 
-```bash
-rm ./debian-nvidia-installer_X.X.X.deb
-```
+### Option 3: Build and install manually (for advanced users)
 
-This removes the `.deb` file, which is no longer needed. It’s optional because all files in `/tmp` are deleted after a system restart.
-
-### Option 3: Build and Install Manually (for Advanced Users)
-
-#### Step 1 – Clone the repository
+Clone the repository locally on your computer using [git](https://packages.debian.org/stable/git):
 
 ```bash
 git clone https://github.com/devleonardoamaral/debian-nvidia-installer.git
 ```
 
-This creates a local copy of the repository on your computer.
-
-#### Step 2 – Build the `.deb` package
+Change to the cloned repository directory:
 
 ```bash
-dpkg-deb --build --root-owner-group debian-nvidia-installer
+cd debian-nvidia-installer
 ```
 
-* Creates the `.deb` file from the repository folder.
-* `--root-owner-group` ensures the file permissions are compatible with the system.
+Run the build script provided in the repository. It will create the `.deb` package in `./deb_build/debian-nvidia-installer_X.X.X_amd64.deb`:
 
-#### Step 3 – Install the package
+```bash
+./build_deb.sh
+```
 
-Use the same steps as [Option 1: Graphical Interface (GUI)](#option-1-graphical-interface-gui) or [Option 2: Terminal](#option-2-terminal). The generated file, `debian-nvidia-installer.deb`, **does not include the version number**.
-
+To install the `.deb` package, follow the same steps as in [Option 1: Graphical Interface (GUI)](#option-1-graphical-interface) or [Option 2: Terminal](#option-2-terminal).
 
 # Uninstallation
+
+To completely remove the script and its dependencies, run the following command:
 
 ```bash
 sudo apt purge --autoremove debian-nvidia-installer
 ```
-
-Removes the package and its configuration files completely, and also cleans up any dependencies that are no longer needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Run the build script provided in the repository. It will create the `.deb` packa
 ./build_deb.sh
 ```
 
-To install the `.deb` package, follow the same steps as in [Option 1: Graphical Interface (GUI)](#option-1-graphical-interface) or [Option 2: Terminal](#option-2-terminal).
+To install the `.deb` package, follow the same steps as in [Option 1: Graphical Interface](#option-1-graphical-interface) or [Option 2: Terminal](#option-2-terminal).
 
 # Uninstallation
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -92,7 +92,7 @@ Execute o script de build disponível no repositório. Ele irá criar o pacote `
 ./build_deb.sh
 ```
 
-Para instalar o pacote `.deb`, siga os mesmos passos das opções [Opção 1: Interface Gráfica (GUI)](#opção-1-interface-gráfica) ou [Opção 2: Terminal](#opção-2-terminal).
+Para instalar o pacote `.deb`, siga os mesmos passos das opções [Opção 1: Interface Gráfica](#opção-1-interface-gráfica) ou [Opção 2: Terminal](#opção-2-terminal).
 
 # Desinstalação
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -47,69 +47,57 @@ Você pode instalar o `debian-nvidia-installer` baixando o pacote `.deb` a parti
 
 ### Opção 2: Terminal
 
-Antes de começar, **verifique a versão do script que você baixou do GitHub**.
-Substitua `X.X.X` nos comandos a seguir pela versão correta.
-Exemplo: se a versão for `0.0.1`, o arquivo será `debian-nvidia-installer_0.0.1.deb`.
+Antes de começar, verifique a versão do pacote .deb que você baixou do GitHub. Substitua `X.X.X` nos comandos a seguir pela versão correta.
+Exemplo: se a versão for `0.0.1`, o arquivo será `debian-nvidia-installer_0.0.1_amd64.deb`.
 
-> ⚠️ **Importante:** não instale o arquivo diretamente do local de download. Sempre mova para o diretório temporário (`/tmp`) para evitar problemas de permissão.
-
-#### Passo 1 – Mover o arquivo para o diretório temporário
+Copie o arquivo `.deb` para o diretório `/tmp`, para evitar problemas de permissão com o gerenciador de pacotes do sistema:
 
 ```bash
-mv ./debian-nvidia-installer_X.X.X.deb /tmp/
+cp ./debian-nvidia-installer_X.X.X_amd64.deb /tmp/
 ```
 
-Isso move o arquivo `.deb` para o diretório `/tmp`, que é seguro para instalar pacotes sem precisar de permissões especiais.
+> 💡 Arquivos dentro do diretório `/tmp` são removidos automaticamente após uma reinicialização do sistema.
 
-#### Passo 2 – Entrar no diretório temporário
+Entre no diretório temporário `/tmp`, onde o arquivo `.deb` foi movido:
 
 ```bash
 cd /tmp
 ```
 
-O comando `cd` significa “change directory” (mudar de diretório). Aqui você entra na pasta `/tmp` onde o arquivo foi movido.
-
-#### Passo 3 – Instalar o pacote
+Instale o pacote utilizando o `apt` para que as dependências do script sejam instaladas corretamente:
 
 ```bash
-sudo apt install ./debian-nvidia-installer_X.X.X.deb
+sudo apt install ./debian-nvidia-installer_X.X.X_amd64.deb
 ```
 
-#### Passo 4 – Limpar o arquivo após a instalação (opcional)
-
-```bash
-rm ./debian-nvidia-installer_X.X.X.deb
-```
-
-Isso remove o arquivo `.deb` que não é mais necessário. É opcional, já que todos os arquivos de `/tmp` são excluídos após reiniciar o sistema.
+> ⚠️ **Importante:** Não instale utilizando `dpkg -i`, isso fará com que as dependências do script não sejam instaladas e o pacote fique quebrado.
 
 ### Opção 3: Construir e instalar manualmente (para usuários avançados)
 
-#### Passo 1 – Clonar o repositório
+Clone o repositório localmente no seu computador utilizando o pacote [git](https://packages.debian.org/stable/git):
 
 ```bash
 git clone https://github.com/devleonardoamaral/debian-nvidia-installer.git
 ```
 
-Isso cria uma cópia local do repositório em seu computador.
-
-#### Passo 2 – Construir o pacote `.deb`
+Entre no diretório do repositório clonado:
 
 ```bash
-dpkg-deb --build --root-owner-group debian-nvidia-installer
+cd debian-nvidia-installer
 ```
 
-* Cria o arquivo `.deb` a partir da pasta do repositório.
-* `--root-owner-group` garante permissões compatíveis com o sistema.
+Execute o script de build disponível no repositório. Ele irá criar o pacote `.deb` em `./deb_build/debian-nvidia-installer_X.X.X_amd64.deb`:
 
-#### Passo 3 – Instalar o pacote
+```bash
+./build_deb.sh
+```
 
-Use os mesmos passos das opções [Opção 1: Interface Gráfica (GUI)](#opção-1-interface-gráfica) ou [Opção 2: Terminal](#opção-2-terminal). O arquivo gerado, `debian-nvidia-installer.deb`, **não inclui o número da versão**.
+Para instalar o pacote `.deb`, siga os mesmos passos das opções [Opção 1: Interface Gráfica (GUI)](#opção-1-interface-gráfica) ou [Opção 2: Terminal](#opção-2-terminal).
 
 # Desinstalação
+
+Para desinstalar corretamente o script e suas dependências, utilize o seguinte comando:
 
 ```bash
 sudo apt purge --autoremove debian-nvidia-installer
 ```
-
-Remove completamente o pacote, incluindo seus arquivos de configuração, e também remove quaisquer dependências que não sejam mais necessárias.


### PR DESCRIPTION
Updates the README to reflect recent changes in the DEB build process.

Changes include:
- Update installation instructions to include `build_deb.sh` and the `deb_build` directory
- Change example DEB filename from `debian-nvidia-installer_X.X.X.deb` to `debian-nvidia-installer_X.X.X_amd64.deb`
- Update uninstall instructions to match the installation instructions
