### PR TITLE
docs(readme): fix architecture requirement to amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It automates steps such as package installation, compatibility checks, and graph
 ### Requirements
 
 * Debian Trixie distribution
-* 64-bit architecture
+* amd64 architecture
 * Compatible NVIDIA graphics card
   > Official NVIDIA drivers on Debian Trixie do not support [GPUs based on the Fermi or Kepler architecture](https://www.nvidia.com/en-us/drivers/unix/legacy-gpu/).
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -15,7 +15,7 @@ verificação de compatibilidade e configuração do ambiente gráfico.
 ### Requisitos
 
 * Distribuição Debian Trixie
-* Arquitetura 64 bits
+* Arquitetura amd64
 * Placa gráfica NVIDIA compatível
   > Os drivers oficiais da NVIDIA no Debian Trixie não oferecem suporte a [GPUs com arquitetura Fermi ou Kepler](https://www.nvidia.com/en-us/drivers/unix/legacy-gpu/).
 


### PR DESCRIPTION
The requirement was previously listed only as "64-bit", but the script does not work on arm64. The README now makes it explicit that only amd64 is supported.