### PR TITLE
feat(scripts): add launch script to run app directly from repository

### DIFF
--- a/debian-nvidia-installer.sh
+++ b/debian-nvidia-installer.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source "./usr/lib/debian-nvidia-installer/packages.sh"
+
+echo "Verifying script dependencies..."
+depends_line=$(grep -E '^Depends:' "./DEBIAN/control" | head -n1)
+depends_list=${depends_line#Depends:}
+depends_list=$(echo "$depends_list" | tr -d ' ')
+depends_list=$(echo "$depends_list" | tr ',' ' ')
+
+for pkg in $depends_list; do
+    if ! packages::is_installed "$pkg"; then
+        echo "Missing dependency: $pkg"
+        exit 1
+    fi
+done
+
+echo "All dependecies are OK!"
+
+echo "Running script..."
+custom_env_vars="env DEVENV=1"
+
+if packages::is_installed "sudo"; then
+    exec gnome-terminal --title="Terminal" -- bash -c "sudo $custom_env_vars ./usr/bin/debian-nvidia-installer; exec bash"
+else
+    exec gnome-terminal --title="Terminal" -- bash -c "$custom_env_vars ./usr/bin/debian-nvidia-installer; exec bash"
+fi


### PR DESCRIPTION
Added a new bash script that allows running the application directly from the repository without building or installing a .deb package. This simplifies development, testing, and debugging by avoiding the packaging step.

- Script sets up environment variables and dependencies paths.
- Ensures the app can locate required libraries and resources.
- Provides informative output if any prerequisite is missing.

This allows contributors and testers to quickly launch the app for development purposes.