### PR TITLE
Remove forced distribution check in main script

### DIFF
--- a/usr/bin/debian-nvidia-installer
+++ b/usr/bin/debian-nvidia-installer
@@ -1,44 +1,112 @@
 #!/usr/bin/env bash
 
+# ============================================================================
 # debian-nvidia-installer - NVIDIA Driver Installer for Debian (TUI)
 # Copyright (C) 2025 Leonardo Amaral
 #
-# This file is part of debian-nvidia-installer.
+# SPDX-License-Identifier:
+#     GPL-3.0-or-later
 #
-# debian-nvidia-installer is free software: you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Module:
+#     debian-nvidia-installer.sh
 #
-# debian-nvidia-installer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with debian-nvidia-installer. If not, see <https://www.gnu.org/licenses/gpl-3.0.html>.
+# Description:
+#     Main file.
+# ============================================================================
 
-declare -g SCRIPT_VERSION="0.0.0"
-declare -g DISTRO_INFO
 
-# Variáveis globais
-declare -g SCRIPT_DIR
-declare -g LOG_FILE_PATH="/var/log/debian-nvidia-installer/debian-nvidia-installer.log"
 
-# Detecta se está em modo desenvolvimento ou produção
-if [[ -n "$DEVENV" ]]; then
-    echo "——— DEVELOPMENT MODE ———"
+
+# ============================================================================
+# Safety Checks
+# ============================================================================
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "Error: This script must be run with Bash." >&2
+    exit 1
+fi
+
+
+
+
+# ============================================================================
+# Main Setup
+# ============================================================================
+
+# Development Mode
+if [[ "$DEVENV" == "1" ]]; then
+    echo "=== DEVELOPMENT MODE ==="
     SCRIPT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/../lib/debian-nvidia-installer")"
 else
     SCRIPT_DIR="/usr/lib/debian-nvidia-installer"
 fi
 
-# Importação dos módulos
+# Ensure directories exist
+mkdir -p "$(dirname "$LOG_FILE_PATH")" || {
+    echo "Warning: Unable to create log directory: $(dirname "$LOG_FILE_PATH")" >&2
+}
+
+# Import modules
 for file in "$SCRIPT_DIR"/translate/*.sh; do source "$file"; done
 for file in "$SCRIPT_DIR"/*.sh; do source "$file"; done
 for file in "$SCRIPT_DIR"/tui/*.sh; do source "$file"; done
 
-# Função de ajuda
+
+
+
+# ============================================================================
+# Enviroment Variables
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Variable: DEVENV
+# Description:
+#     Defines if the script should be executed in development mode.
+#     This will replace paths to execute with source code structure.
+# ----------------------------------------------------------------------------
+: "${DEVENV:=0}"
+
+
+
+
+# ============================================================================
+# Global Variables
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Variable: SCRIPT_DIR
+# Description:
+#     Script root directory.
+# ----------------------------------------------------------------------------
+declare -g SCRIPT_DIR
+
+# ----------------------------------------------------------------------------
+# Variable: SCRIPT_VERSION
+# Description:
+#     Version of the script.
+# ----------------------------------------------------------------------------
+declare -g SCRIPT_VERSION="0.0.0"
+
+# ----------------------------------------------------------------------------
+# Variable: LOG_FILE_PATH
+# Description:
+#     Path to the log file.
+# ----------------------------------------------------------------------------
+declare -g LOG_FILE_PATH="/var/log/debian-nvidia-installer/debian-nvidia-installer.log"
+
+
+
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Function: script::help
+# Description:
+#     Shows help tip.
+# Params:
+#     None
+# ----------------------------------------------------------------------------
 script::help() {
     local script_name
     script_name=$(basename "$0")
@@ -67,7 +135,13 @@ tr::add "en_US" "script::help.cmd.version" "Displays the script version."
 tr::add "en_US" "script::help.cmd.help" "Shows this help message."
 tr::add "en_US" "script::help.examples" "Examples:"
 
-# Limpeza / Encerramento
+# ----------------------------------------------------------------------------
+# Function: script::exit
+# Description:
+#     Shows help tip.
+# Params:
+#     None
+# ----------------------------------------------------------------------------
 script::exit() {
     local exit_message
     local return_code
@@ -89,20 +163,22 @@ script::exit() {
 tr::add "pt_BR" "script::exit.informlogpath" "O resumo da última execução do script está disponível em: %1"
 tr::add "en_US" "script::exit.informlogpath" "The summary of the last script execution is available at: %1"
 
+# ----------------------------------------------------------------------------
+# Function: main::requirements
+# Description:
+#     Requirement checks.
+# Params:
+#     None
+# ----------------------------------------------------------------------------
 script::requirements() {
-    # Garante que o script só seja executado na versão correta
-    if [[ "$DISTRO_INFO" != "debian 13 (trixie)" ]]; then
-        script::exit "$(tr::t_args "script::requirements.invalid_distro" "$DISTRO_INFO")" 1
-    fi
-
-    # Garante que o script só seja executado com privilégios root
+    # Ensure administrator permissions
     if ! utils::check_sudo; then
         log::warn "$(tr::t "default.script.rootaccess.required")"
         utils::force_sudo "$@" # Reexecuta o script
         script::exit "" 1
     fi
 
-    # Verifica e instala pacotes obrigatórios para execução do script
+    # Check and installs dependencies
     log::info "$(tr::t "script::requirements.verifying")"
     if packages::install "dialog"; then
         log::info "$(tr::t "script::requirements.success")"
@@ -122,62 +198,75 @@ tr::add "en_US" "script::requirements.verifying" "Verifying script dependencies.
 tr::add "en_US" "script::requirements.success" "Dependencies verified successfully."
 tr::add "en_US" "script::requirements.failure" "Failed to verify dependencies."
 
-# Define o idioma do script com base no sistema
-tr::detect_language
+# ----------------------------------------------------------------------------
+# Function: main
+# Description:
+#     Main function.
+# Params:
+#     None
+# ----------------------------------------------------------------------------
+main() {
+    # Language setup
+    tr::detect_language
 
-# Processa os argumentos
-tr::add "pt_BR" "default.invalid.command" "Comando inválido: %1"
-tr::add "en_US" "default.invalid.command" "Invalid command: %1"
+    # CLI arguments processing
+    if [[ $# -gt 0 ]]; then
+        case "$1" in
+            --version|--VERSION|-v|-V)
+                echo "$SCRIPT_VERSION"
+                exit 0
+                ;;
+            --help|--HELP|-h|-H)
+                script::help
+                exit 0
+                ;;
+            *)
+                echo "$(tr::t_args "default.invalid.command" "$*")"
+                script::help
+                exit 1
+                ;;
+        esac
+    fi
 
-if [[ $# -gt 0 ]]; then
-    case "$1" in
-        --version|--VERSION|-v|-V)
-            echo "$SCRIPT_VERSION"
-            exit 0
-            ;;
-        --help|--HELP|-h|-H)
-            script::help
-            exit 0
-            ;;
-        *)
-            echo "$(tr::t_args "default.invalid.command" "$*")"
-            script::help
-            exit 1
-            ;;
-    esac
-
-# Executa o script
-else
-    source "/etc/os-release"
-    DISTRO_INFO="$ID $VERSION_ID ($VERSION_CODENAME)"
-
-    # Configura arquivos de logging
+    # Setup logger
     log::setup_logger "$LOG_FILE_PATH"
 
-    # Exibe a mensagem de boas-vindas
-    tr::add "pt_BR" "default.script.welcome" "Debian NVIDIA Installer v%1\n
-  > Este instalador é distribuído sob a licença GPLv3.
-  > Repositório do projeto: https://github.com/devleonardoamaral/debian-nvidia-installer
+    # Show the wellcome message
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        source /etc/os-release
+        log::info "$(tr::t_args "default.script.welcome" "$SCRIPT_VERSION" "$PRETTY_NAME")"
+    else
+        log::info "$(tr::t_args "default.script.welcome" "$SCRIPT_VERSION" "$(tr::t "default.script.distro.unknown")")"
+    fi
+
+    # Check and install requirements
+    script::requirements "$@"
+
+    # Start maio dialog
+    tui::menu::main
+    ret=$?
+
+    # Clean and exit
+    script::exit "" "$ret"
+}
+
+tr::add "pt_BR" "default.script.distro.unknown" "Distribuição não detectada"
+tr::add "pt_BR" "default.invalid.command" "Comando inválido: %1"
+tr::add "pt_BR" "default.script.welcome" "Debian NVIDIA Installer v%1\n
+> Este instalador é distribuído sob a licença GPLv3.
+> Repositório do projeto: https://github.com/devleonardoamaral/debian-nvidia-installer
 
 Distribuição: %2\n
 "
 
-    tr::add "en_US" "default.script.welcome" "Welcome to the Debian NVIDIA Installer %1\n
-  > This installer is released under the GPLv3 license.
-  > Project repository: https://github.com/devleonardoamaral/debian-nvidia-installer
+tr::add "en_US" "default.script.distro.unknown" "Unknown distribution"
+tr::add "en_US" "default.invalid.command" "Invalid command: %1"
+tr::add "en_US" "default.script.welcome" "Welcome to the Debian NVIDIA Installer %1\n
+> This installer is released under the GPLv3 license.
+> Project repository: https://github.com/devleonardoamaral/debian-nvidia-installer
 
 Distribution: %2\n
 "
-    (
-        source "/etc/os-release"
-        log::info "$(tr::t_args "default.script.welcome" "$SCRIPT_VERSION" "$DISTRO_INFO")"
-    )
 
-    # Verifica requisitos do script
-    script::requirements "$@"
-
-    # Inicia o Dialog de navegação
-    tui::menu::main
-    ret=$?
-    script::exit "" "$ret"
-fi
+main


### PR DESCRIPTION
This PR removes the hardcoded distribution check from the script requirements:

### Changes
1. Script no longer exits if run on non-Debian systems.
2. Distribution detection now has a fallback for unknown distributions.
3. Welcome message logs the detected distribution consistently.
4. Minor refactor of debian-nvidia-installer.sh file for readability.

> ### ⚠️ Warning
> The script may still fail or behave unexpectedly on unsupported distributions. 
> This change only removes the blocking mechanism, it does not guarantee compatibility.

Closes #35
